### PR TITLE
fix: set specific golang version (build does not work on newer versions)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS builder
+FROM golang:1.15-alpine AS builder
 WORKDIR $GOPATH/src/app/
 RUN apk add --no-cache git
 ADD . .


### PR DESCRIPTION
This is a fix for the Docker build. Another option is to support the newer version of golang. 