### PR TITLE
fix: updated Dockerfile to match github build version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine AS builder
+FROM golang:1.18-alpine AS builder
 WORKDIR $GOPATH/src/app/
 RUN apk add --no-cache git
 ADD . .


### PR DESCRIPTION
This fixes the following Docker build error:

```
2.687 /go/pkg/mod/golang.org/x/sys@v0.1.0/unix/syscall.go:83:16: undefined: unsafe.Slice
2.687 /go/pkg/mod/golang.org/x/sys@v0.1.0/unix/syscall_linux.go:2255:9: undefined: unsafe.Slice
2.687 /go/pkg/mod/golang.org/x/sys@v0.1.0/unix/syscall_unix.go:118:7: undefined: unsafe.Slice
2.687 /go/pkg/mod/golang.org/x/sys@v0.1.0/unix/sysvshm_unix.go:33:7: undefined: unsafe.Slice
```