### PR TITLE
make usb serial port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Usage of ./prometheus-p1-exporter:
         Listen address for HTTP metrics (default "127.0.0.1:8888")
   -mock
         Use dummy source instead of ttyUSB0 socket
+  -usbserial string
+    	USB serial device (default "/dev/ttyUSB0")
   -verbose
         Verbose output logging
 ```

--- a/conn/source_serial.go
+++ b/conn/source_serial.go
@@ -6,15 +6,19 @@ import (
 	"github.com/jacobsa/go-serial/serial"
 )
 
-type SerialSource struct{}
-
-func NewSerialSource() Source {
-	return &SerialSource{}
+type SerialSource struct{
+	UsbSerial string
 }
 
-func (SerialSource) ReadFromSource(telegramOptions *TelegramReaderOptions) (io.ReadCloser, error) {
+func NewSerialSource(usbSerial string) Source {
+	return &SerialSource{
+		UsbSerial: usbSerial,
+	}
+}
+
+func (s *SerialSource) ReadFromSource(telegramOptions *TelegramReaderOptions) (io.ReadCloser, error) {
 	options := serial.OpenOptions{
-		PortName:        "/dev/ttyUSB0",
+		PortName:        s.UsbSerial,
 		BaudRate:        telegramOptions.BaudRate,
 		DataBits:        telegramOptions.DataBits,
 		StopBits:        telegramOptions.StopBits,

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ var apiEndpoint string
 var useMock bool
 var verbose bool
 var metricNamePrefix = "p1_"
+var usbSerial string
 
 var (
 	registry                   = prometheus.NewRegistry()
@@ -84,6 +85,7 @@ func main() {
 	flag.BoolVar(&useMock, "mock", false, "Use dummy source instead of ttyUSB0 socket")
 	flag.StringVar(&apiEndpoint, "apiEndpoint", "", "Use API endpoint to read the telegram (use for HomeWizard)")
 	flag.BoolVar(&verbose, "verbose", false, "Verbose output logging")
+	flag.StringVar(&usbSerial, "usbserial", "/dev/ttyUSB0", "USB serial device")
 	flag.Parse()
 
 	var source conn.Source
@@ -92,7 +94,7 @@ func main() {
 	} else if apiEndpoint != "" {
 		source = conn.NewAPISource(apiEndpoint)
 	} else {
-		source = conn.NewSerialSource()
+		source = conn.NewSerialSource(usbSerial)
 	}
 
 	logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})


### PR DESCRIPTION
This patch adds a command line parameter to make the usb serial port configurable.

My first ever commit to anything written in Go, but I don't think this should have any issues...